### PR TITLE
Also accept offset date times as input for Instant

### DIFF
--- a/src/main/java/net/dongliu/gson/Java8TimeAdapter.java
+++ b/src/main/java/net/dongliu/gson/Java8TimeAdapter.java
@@ -17,10 +17,10 @@ import static java.time.format.DateTimeFormatter.*;
  * @author Liu Dong
  */
 class Java8TimeAdapter extends TypeAdapter<TemporalAccessor> {
-    private final DateTimeFormatter dtf;
+    private final DateTimeFormatter readFormatter, writeFormatter;
     private final TemporalQuery<TemporalAccessor> temporalQuery;
 
-    static final Java8TimeAdapter instantAdapter = new Java8TimeAdapter(ISO_INSTANT, Instant::from);
+    static final Java8TimeAdapter instantAdapter = new Java8TimeAdapter(ISO_OFFSET_DATE_TIME, ISO_INSTANT, Instant::from);
     static final Java8TimeAdapter localDateAdapter = new Java8TimeAdapter(ISO_LOCAL_DATE, LocalDate::from);
     static final Java8TimeAdapter localDateTimeAdapter = new Java8TimeAdapter(ISO_LOCAL_DATE_TIME, LocalDateTime::from);
     static final Java8TimeAdapter localTimeAdapter = new Java8TimeAdapter(ISO_LOCAL_TIME, LocalTime::from);
@@ -29,7 +29,12 @@ class Java8TimeAdapter extends TypeAdapter<TemporalAccessor> {
     static final Java8TimeAdapter zonedDateTimeAdapter =new Java8TimeAdapter(ISO_ZONED_DATE_TIME, ZonedDateTime::from);
 
     public Java8TimeAdapter(DateTimeFormatter dtf, TemporalQuery<TemporalAccessor> temporalQuery) {
-        this.dtf = dtf;
+        this(dtf, dtf, temporalQuery);
+    }
+
+    public Java8TimeAdapter(final DateTimeFormatter readFormatter, final DateTimeFormatter writeFormatter, final TemporalQuery<TemporalAccessor> temporalQuery) {
+        this.readFormatter = readFormatter;
+        this.writeFormatter = writeFormatter;
         this.temporalQuery = temporalQuery;
     }
 
@@ -40,7 +45,7 @@ class Java8TimeAdapter extends TypeAdapter<TemporalAccessor> {
             out.nullValue();
             return;
         }
-        String str = dtf.format(value);
+        String str = writeFormatter.format(value);
         out.value(str);
     }
 
@@ -51,6 +56,6 @@ class Java8TimeAdapter extends TypeAdapter<TemporalAccessor> {
             return null;
         }
         String str = in.nextString();
-        return dtf.parse(str, temporalQuery);
+        return readFormatter.parse(str, temporalQuery);
     }
 }

--- a/src/test/java/net/dongliu/gson/GsonJava8TypeAdapterFactoryTest.java
+++ b/src/test/java/net/dongliu/gson/GsonJava8TypeAdapterFactoryTest.java
@@ -27,6 +27,7 @@ public class GsonJava8TypeAdapterFactoryTest {
         Instant instant = Instant.ofEpochMilli(1457595643101L);
         assertEquals("\"2016-03-10T07:40:43.101Z\"", gson.toJson(instant));
         assertEquals(instant, gson.fromJson("\"2016-03-10T07:40:43.101Z\"", Instant.class));
+        assertEquals(instant, gson.fromJson("\"2016-03-10T08:40:43.101+01:00\"", Instant.class));
         ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
         assertEquals("\"2016-03-10T15:40:43.101+08:00[Asia/Shanghai]\"", gson.toJson(zonedDateTime));
         assertEquals(zonedDateTime, gson.fromJson("\"2016-03-10T15:40:43.101+08:00[Asia/Shanghai]\"", ZonedDateTime.class));


### PR DESCRIPTION
Currently, the `TypeAdapter` for `Instant` is very restrictive: it only accepts date-time strings in UTC. But since date-time strings with different offsets than `"Z"` can also safely be converted to `Instant` values, it would be cool if it would also accept those strings. It would make the parser more versatile without getting fuzzy (["be liberal in what you accept"](https://en.wikipedia.org/wiki/Robustness_principle)).

If you think this is undesired behavior, would you then accept a PR that adds additional configuration facilities?